### PR TITLE
design: 메뉴 버튼 간격 조정

### DIFF
--- a/client/src/components/menu/menu.module.scss
+++ b/client/src/components/menu/menu.module.scss
@@ -64,6 +64,7 @@
 .active_user_number {
     display: flex;
     align-items: center;
+    margin-left: 8px;
     font-size: 12px;
     font-weight: 700;
 
@@ -85,6 +86,6 @@
         background-image: url(/chat.svg);
         background-repeat: no-repeat;
         background-size: 26px;
-        background-position: 12px 11px;
+        background-position: 11px 11px;
     }
 }

--- a/client/src/components/menu/menu.tsx
+++ b/client/src/components/menu/menu.tsx
@@ -2,6 +2,8 @@
 
 import { useAtom, useSetAtom } from "jotai";
 import { modalAtom, isTimerVisibleAtom, timerAtom } from "@/jotai/atom";
+import Image from "next/image";
+import active_user_icon from "/public/active_user.svg";
 import TimerSetting from "../timer/timerSetting";
 import Timer from "../timer/timer";
 import style from "./menu.module.scss";
@@ -38,7 +40,7 @@ const Menu = (props: IMenu) => {
                     <button className={style.screen_share} aria-label="화면 공유하기"></button>
                 </li>
                 <li className={style.active_user_number}>
-                    <img src="/active_user.svg" alt="접속자 수" />
+                    <Image src={active_user_icon} alt="접속자 수" />
                     <span className={style.active_circle}>●</span>
                     <span>2</span>
                 </li>


### PR DESCRIPTION
## 개요
<!-- 한 줄 정도로 어떤 PR인지 설명해주세요 -->
하단 메뉴의 일정하지 않았던 간격을 일정하게 조정했습니다.
(겸사겸사 img 태그도 수정했습니다^^;)

## 작업 사항
<!-- 가능하다면 스크린샷을 첨부해주세요 -->
<img width="294" alt="스크린샷 2023-10-12 오후 10 11 57" src="https://github.com/FE-Ocean/meetsin/assets/102905624/f5a9c068-359d-4b2b-bc92-884e81a4e2a8">

- 메뉴 간격 조정
- `img` 태그 => `Image` 태그로 변경

