### PR TITLE
feat: FetchClient, FetchError

### DIFF
--- a/client/src/modules/error.ts
+++ b/client/src/modules/error.ts
@@ -1,0 +1,5 @@
+export class FetchError extends Error {
+    constructor(public message: string, public statusCode: number, public statusText: string) {
+        super();
+    }
+}

--- a/client/src/modules/fetchClient.ts
+++ b/client/src/modules/fetchClient.ts
@@ -1,0 +1,76 @@
+import { FetchError } from "./error";
+
+interface FetchClientOptions {
+    baseURL: string;
+    config: RequestInit;
+}
+
+export class FetchClient {
+    constructor(private baseURL: string, private config: RequestInit = {}) {}
+
+    static create(options: FetchClientOptions) {
+        return new FetchClient(options.baseURL, options.config);
+    }
+
+    public get<T>(path: string, config: RequestInit = {}): Promise<T> {
+        return this.request<T>(path, { ...config, method: "GET" });
+    }
+
+    public post<T>(
+        path: string,
+        body?: BodyInit | Record<string, unknown>,
+        config: RequestInit = {},
+    ): Promise<T> {
+        const requestBody = body instanceof FormData ? body : JSON.stringify(body);
+        return this.request<T>(path, { ...config, method: "POST", body: requestBody });
+    }
+
+    public delete<T>(path: string, config: RequestInit = {}): Promise<T> {
+        return this.request<T>(path, { ...config, method: "DELETE" });
+    }
+
+    public patch<T>(
+        path: string,
+        body: BodyInit | Record<string, unknown>,
+        config: RequestInit = {},
+    ): Promise<T> {
+        const requestBody = body instanceof FormData ? body : JSON.stringify(body);
+        return this.request<T>(path, { ...config, method: "PATCH", body: requestBody });
+    }
+
+    private async request<T>(path: string, config: RequestInit): Promise<T> {
+        const url = this.baseURL + path;
+        const requestConfig: RequestInit = {
+            ...this.config,
+            ...config,
+        };
+
+        try {
+            const response = await fetch(url, requestConfig);
+
+            if (!response.ok) {
+                const errorBody = await response.json();
+                throw new FetchError(errorBody.message, response.status, response.statusText);
+            }
+
+            const data = await response.json();
+            return data;
+        } catch (error) {
+            if (error instanceof FetchError) {
+                throw error;
+            } else {
+                throw new Error("Unknown Error");
+            }
+        }
+    }
+}
+
+export const baseClient = FetchClient.create({
+    baseURL: "http://localhost:8000",
+    config: {
+        headers: {
+            "Content-Type": "application/json",
+        },
+        credentials: "include",
+    },
+});


### PR DESCRIPTION
## 개요
next 내장 fetch 와 error를 한번 감싸서 기본 옵션 설정할수있게 작업했습니다.

fetchClient.ts 파일에 baseClient로 현재 저희 서버 포트랑 기본 설정 만들어놨습니다.

현재 저는 baseClient 만들어두고 baseClient.get() baseClient.post() ... 이런식으로 사용하고 추가 설정 필요하면 여기에서 더 추가하고있습니다.

## 작업 사항


## 리뷰 요청 사항
에러 클래스는 나중에 에러 처리때문에 따로 만들어두긴했는데 아직 처리를 못해서,, 조금 더 공부하고 해봐야할꺼같습니다,,