### PR TITLE
change: user 스키마의 'user_id' => '_id' 필드 사용으로 변경

### DIFF
--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, ForbiddenException, HttpException, HttpStatus, Injectable } from "@nestjs/common";
+import { BadRequestException, ForbiddenException, Injectable } from "@nestjs/common";
 import { UserEntity } from "src/schema/user.schema";
 import { UsersRepository } from "src/users/users.repository";
 import dotenv from "dotenv";
@@ -17,33 +17,33 @@ export class AuthService {
 
     async signIn(req: LoginRequest, res: Response) {
         try {
-            const userData = req.user as UserEntity
+            const userData = req.user as UserEntity;
 
             let user: UserEntity;
 
-            if(!userData){
-                throw new BadRequestException('Unauthenticated');
+            if (!userData) {
+                throw new BadRequestException("Unauthenticated");
             }
 
-            user = await this.usersRepository.findUserById(userData.user_id);
+            user = await this.usersRepository.findUserById(userData._id);
 
-            if(!user) {
+            if (!user) {
                 user = await this.signUp(userData);
             }
-            
+
             const jwtPayload = {
-                id: user.user_id,
-                email: user.email
-            }
+                id: user._id,
+                email: user.email,
+            };
 
-            const accessToken = this.jwtService.sign(jwtPayload)
+            const accessToken = this.jwtService.sign(jwtPayload);
 
-            await this.usersRepository.updateAccessToken(user, accessToken)
-            
+            await this.usersRepository.updateAccessToken(user, accessToken);
+
             return {
-                access_token: accessToken
-            }
-        } catch(error) {
+                access_token: accessToken,
+            };
+        } catch (error) {
             throw new ForbiddenException("Signin Failed");
         }
     }

--- a/server/src/auth/google.strategy.ts
+++ b/server/src/auth/google.strategy.ts
@@ -32,12 +32,11 @@ export class GoogleStrategy extends PassportStrategy(Strategy, "google") {
         done: VerifyCallback,
     ) {
         try {
-            const { id, emails, photos, displayName } = profile;
+            const { emails, photos, displayName } = profile;
             const objectId = new Types.ObjectId();
 
             const userInfo: UserEntity = {
                 _id: objectId,
-                user_id: id, // 이거 social_id로 이름 바꾸는 거 어떤지
                 email: emails[0].value,
                 profile_img: photos[0].value,
                 user_name: displayName,

--- a/server/src/auth/google.strategy.ts
+++ b/server/src/auth/google.strategy.ts
@@ -4,12 +4,12 @@ import { Profile, Strategy, VerifyCallback } from "passport-google-oauth20";
 import { UserEntity } from "src/schema/user.schema";
 import { AuthService } from "./auth.service";
 import dotenv from "dotenv";
+import { Types } from "mongoose";
 
 dotenv.config();
 
 @Injectable()
-
-export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
+export class GoogleStrategy extends PassportStrategy(Strategy, "google") {
     constructor(private authService: AuthService) {
         super({
             clientID: process.env.GOOGLE_CLIENT_ID,
@@ -21,15 +21,23 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
 
     authorizationParams(options: any): object {
         return {
-            access_type: 'offline'
-        }
+            access_type: "offline",
+        };
     }
 
-    async validate(accessToken: string, refreshToken: string, profile: Profile, done: VerifyCallback) {
+    async validate(
+        accessToken: string,
+        refreshToken: string,
+        profile: Profile,
+        done: VerifyCallback,
+    ) {
         try {
-            const {id, emails, photos, displayName} = profile;
+            const { id, emails, photos, displayName } = profile;
+            const objectId = new Types.ObjectId();
+
             const userInfo: UserEntity = {
-                user_id: id,
+                _id: objectId,
+                user_id: id, // 이거 social_id로 이름 바꾸는 거 어떤지
                 email: emails[0].value,
                 profile_img: photos[0].value,
                 user_name: displayName,
@@ -40,6 +48,5 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
         } catch (error) {
             done(error);
         }
-        
     }
 }

--- a/server/src/auth/jwt.strategy.ts
+++ b/server/src/auth/jwt.strategy.ts
@@ -9,20 +9,19 @@ import { JwtPayload } from "jsonwebtoken";
 dotenv.config();
 
 @Injectable()
-
-export class JwtStrategy extends PassportStrategy(Strategy){
+export class JwtStrategy extends PassportStrategy(Strategy) {
     constructor(private readonly config: ConfigService) {
         super({
             jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
             ignoreExpiration: false,
             secretOrKey: process.env.JWT_SECRET,
-        })
+        });
     }
 
     async validate(payload: JwtPayload) {
         return {
-            user_id: payload.id,
+            _id: payload.id,
             email: payload.email,
-        }
+        };
     }
 }

--- a/server/src/auth/kakao.strategy.ts
+++ b/server/src/auth/kakao.strategy.ts
@@ -19,12 +19,11 @@ export class KakaoStrategy extends PassportStrategy(Strategy, "kakao") {
         done: (error: Error, user?: UserEntity) => void,
     ) {
         try {
-            const { id, _json: json, displayName } = profile;
+            const { _json: json, displayName } = profile;
             const objectId = new Types.ObjectId();
 
             const userInfo: UserEntity = {
                 _id: objectId,
-                user_id: id,
                 email: json.kakao_account.email,
                 profile_img: json.kakao_account.profile.profile_image_url,
                 user_name: displayName,

--- a/server/src/auth/kakao.strategy.ts
+++ b/server/src/auth/kakao.strategy.ts
@@ -1,20 +1,29 @@
 import { PassportStrategy } from "@nestjs/passport";
 import { Profile, Strategy } from "passport-kakao";
+import { Types } from "mongoose";
 import { UserEntity } from "src/schema/user.schema";
 
-export class KakaoStrategy extends PassportStrategy(Strategy, 'kakao') {
+export class KakaoStrategy extends PassportStrategy(Strategy, "kakao") {
     constructor() {
         super({
             clientID: process.env.KAKAO_CLIENT_ID,
             clientSecret: process.env.KAKAO_CLIENT_SECRET,
             callbackURL: `${process.env.SERVER_URL}/auth/redirect/kakao`,
-        })
+        });
     }
 
-    async validate(accessToken: string, refreshToken: string, profile: Profile, done: (error: Error, user?: UserEntity) => void) {
+    async validate(
+        accessToken: string,
+        refreshToken: string,
+        profile: Profile,
+        done: (error: Error, user?: UserEntity) => void,
+    ) {
         try {
-            const {id, _json:json, displayName} = profile;
+            const { id, _json: json, displayName } = profile;
+            const objectId = new Types.ObjectId();
+
             const userInfo: UserEntity = {
+                _id: objectId,
                 user_id: id,
                 email: json.kakao_account.email,
                 profile_img: json.kakao_account.profile.profile_image_url,
@@ -24,8 +33,7 @@ export class KakaoStrategy extends PassportStrategy(Strategy, 'kakao') {
             };
             done(null, userInfo);
         } catch (error) {
-            done(error);   
+            done(error);
         }
-        
     }
 }

--- a/server/src/rooms/rooms.controller.ts
+++ b/server/src/rooms/rooms.controller.ts
@@ -18,7 +18,7 @@ export class RoomsController {
 
     @Get("user")
     getRoomsByUserId(@CurrentUser() user: UserEntity) {
-        return this.roomsService.getRoomsByUserId(user.user_id);
+        return this.roomsService.getRoomsByUserId(user._id);
     }
 
     @Get(":roomId")

--- a/server/src/rooms/rooms.service.ts
+++ b/server/src/rooms/rooms.service.ts
@@ -1,21 +1,20 @@
 import { Injectable, NotFoundException } from "@nestjs/common";
 import { InjectModel } from "@nestjs/mongoose";
-import { Model } from "mongoose";
-import { UserEntity } from "src/schema/user.schema";
+import { Model, Types } from "mongoose";
 import { Room } from "./rooms.schema";
+import { UserEntity } from "src/schema/user.schema";
 import { CreateRoomDto } from "./dto/create-room.dto";
-
 
 @Injectable()
 export class RoomsService {
     constructor(@InjectModel(Room.name) private roomModel: Model<Room>) {}
 
     createRoom(roomData: CreateRoomDto, user: UserEntity) {
-        const newRoom = new this.roomModel({ room_name: roomData.roomName, admin: user.user_id });
+        const newRoom = new this.roomModel({ room_name: roomData.roomName, admin: user._id });
         return newRoom.save();
     }
 
-    async getRoomsByUserId(userId: string) {
+    async getRoomsByUserId(userId: Types.ObjectId) {
         const rooms = await this.roomModel.find({ admin: userId }).exec();
 
         if (!rooms) {

--- a/server/src/schema/user.schema.ts
+++ b/server/src/schema/user.schema.ts
@@ -15,12 +15,6 @@ export class UserEntity {
 
     @Prop({
         required: true,
-        unique: true,
-    })
-    user_id: string;
-
-    @Prop({
-        required: true,
     })
     user_name: string;
 

--- a/server/src/schema/user.schema.ts
+++ b/server/src/schema/user.schema.ts
@@ -1,15 +1,18 @@
 import { OmitType } from "@nestjs/mapped-types";
 import { Prop, Schema, SchemaFactory, SchemaOptions } from "@nestjs/mongoose";
-import { HydratedDocument } from "mongoose";
+import { Types } from "mongoose";
 
 const options: SchemaOptions = {
     timestamps: true,
     collection: "Users",
+    versionKey: false,
 };
 
 // DB에 저장되는 유저 정보 (토큰 포함)
 @Schema(options)
 export class UserEntity {
+    _id?: Types.ObjectId;
+
     @Prop({
         required: true,
         unique: true,
@@ -40,6 +43,6 @@ export class UserEntity {
 }
 
 // 클라이언트에 제공되는 유저 정보 (토큰 미포함)
-export class UserDto extends OmitType(UserEntity, ['access_token', 'refresh_token']) {}
+export class UserDto extends OmitType(UserEntity, ["access_token", "refresh_token"]) {}
 
 export const UserSchema = SchemaFactory.createForClass(UserEntity);

--- a/server/src/users/users.repository.ts
+++ b/server/src/users/users.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import { InjectModel } from "@nestjs/mongoose";
-import { Model } from "mongoose";
+import { Model, Types } from "mongoose";
 import { UserEntity } from "src/schema/user.schema";
 
 @Injectable()
@@ -10,19 +10,19 @@ export class UsersRepository {
     createUser(userData: UserEntity) {
         return {
             ...userData,
-        } as UserEntity
+        } as UserEntity;
     }
 
-    async findUserById(user_id: string) {
-        const user = await this.userModel.findOne({ user_id });
+    async findUserById(_id: Types.ObjectId) {
+        const user = await this.userModel.findOne({ _id });
         return user;
     }
 
     async saveUser(userData: UserEntity) {
         await this.userModel.create(userData);
     }
-    
+
     async updateAccessToken(user: UserEntity, accessToken: string) {
-        await this.userModel.updateOne({user_id: user.user_id}, {access_token: accessToken})
+        await this.userModel.updateOne({ _id: user._id }, { access_token: accessToken });
     }
 }

--- a/server/src/users/users.service.ts
+++ b/server/src/users/users.service.ts
@@ -6,13 +6,13 @@ import { UsersRepository } from "./users.repository";
 export class UsersService {
     constructor(private readonly usersRepository: UsersRepository) {}
 
-    entityToDto (user: UserEntity) {
+    entityToDto(user: UserEntity) {
         const userDto = new UserDto();
-        userDto.user_id = user.user_id;
+        userDto._id = user._id;
         userDto.email = user.email;
         userDto.user_name = user.user_name;
         userDto.profile_img = user.profile_img;
         userDto.character = user.character;
-        return userDto
+        return userDto;
     }
 }


### PR DESCRIPTION
## 개요
<!-- 한 줄 정도로 어떤 PR인지 설명해주세요 -->
**user schema의 `user_id` 필드 사용하고 있던 곳들을 *`_id`* 필드를 사용하도록 변경**

## 작업 사항
<!-- 가능하다면 스크린샷을 첨부해주세요 -->
user_id를 사용하고 있던 여러 함수들 `_id` 쓰도록 변경
- user 스키마 건드는 김에 `versinonKey: false`도 추가


## 리뷰 요청 사항
**Q1**. 처음에는 user_id 필드를 아예 날려버릴 생각이었는데, 카카오랑 구글 strategy파일의 validate 함수에서 user_id 필드에 가져온 id를 넣길래..이것도 필요한 id인가..? 해서 일단 냅뒀습니다! 
이거 사용한다면 이름 user_id말고 social_id라던가..로 바꾸는 거 어떤지요
필요없다면 알려주세요 지우겠습니다
**=> user_id 사용해야 하나요?**

**Q2**. 클라에서..는 user_id 이름 그대로 둘까 싶은데 어때요
<br>

------
> **참고사항**: 기존 MongoDB에 있는 가입 데이터들로 로그인하면 제대로 동작 안 할 거여요! 다 날리려다 혹시나해서 놔뒀으니 기존 아이디로 이용하려면 DB에서 지우고 다시 하시길..
