### PR TITLE
fix: fetchClient config 수정

### DIFF
--- a/client/src/app/api/repository/room.repository.ts
+++ b/client/src/app/api/repository/room.repository.ts
@@ -1,16 +1,21 @@
-import { baseClient } from "@/modules/fetchClient";
+import { addAuthHeader, baseClient } from "@/modules/fetchClient";
 import { IPatchRoom } from "@/types/room";
 
-export const getRoomInfo = async (roomId: string, accessToken: string) => {
-    if (!accessToken) {
-        throw new Error("access token이 없거나 올바르지 않습니다."); //이거 어디서
-    }
+// export const getRoomInfo = async (roomId: string, accessToken: string) => {
+//     if (!accessToken) {
+//         throw new Error("access token이 없거나 올바르지 않습니다."); //이거 어디서
+//     }
 
-    return await baseClient.get(`/rooms/${roomId}`, {
-        headers: {
-            Authorization: `Bearer ${accessToken}`,
-        },
-    });
+//     return await baseClient.get(`/rooms/${roomId}`, {
+//         headers: {
+//             Authorization: `Bearer ${accessToken}`,
+//         },
+//     });
+// };
+
+export const getRoomInfo = async (roomId: string, accessToken: string) => {
+    const authConfig = addAuthHeader(accessToken);
+    return await baseClient.get(`/rooms/${roomId}`, authConfig);
 };
 
 export const getUserRooms = async (accessToken: string) => {
@@ -52,31 +57,43 @@ export const createRoom = async (roomNameInput: string, accessToken: string) => 
     }
 };
 
+// export const patchRoom = async ({ roomName, roomId, accessToken }: IPatchRoom) => {
+//     try {
+//         if (!accessToken) {
+//             throw new Error("access token이 없거나 올바르지 않습니다.");
+//         }
+
+//         const url = `${process.env.NEXT_PUBLIC_SERVER_URL}/rooms/${roomId}`;
+//         const response = await fetch(url, {
+//             method: "PATCH",
+//             headers: {
+//                 "Content-Type": "application/json",
+//                 Authorization: `Bearer ${accessToken}`,
+//             },
+//             body: JSON.stringify({ roomData: { roomName } }),
+//         });
+
+//         if (!response.ok) {
+//             throw new Error(`PATCH room 실패: ${response.statusText}`);
+//         }
+
+//         return response.json();
+//     } catch (error) {
+//         console.error(error);
+//         throw error;
+//     }
+// };
+
 export const patchRoom = async ({ roomName, roomId, accessToken }: IPatchRoom) => {
-    try {
-        if (!accessToken) {
-            throw new Error("access token이 없거나 올바르지 않습니다.");
-        }
+    const authConfig = addAuthHeader(accessToken);
 
-        const url = `${process.env.NEXT_PUBLIC_SERVER_URL}/rooms/${roomId}`;
-        const response = await fetch(url, {
-            method: "PATCH",
-            headers: {
-                "Content-Type": "application/json",
-                Authorization: `Bearer ${accessToken}`,
-            },
-            body: JSON.stringify({ roomData: { roomName } }),
-        });
-
-        if (!response.ok) {
-            throw new Error(`PATCH room 실패: ${response.statusText}`);
-        }
-
-        return response.json();
-    } catch (error) {
-        console.error(error);
-        throw error;
-    }
+    return await baseClient.patch(
+        `/rooms/${roomId}`,
+        {
+            roomData: { roomName },
+        },
+        authConfig,
+    );
 };
 
 export const deleteRoom = async (roomId: string, accessToken: string) => {

--- a/client/src/app/lobby/page.tsx
+++ b/client/src/app/lobby/page.tsx
@@ -14,15 +14,15 @@ const Lobby = () => {
     const { onOpen } = useModal("createRoom");
 
     const accessToken = useAtomValue(accessTokenAtom);
-    const [userRooms, setUserRoom] = useState<IRoom[]>([]);
+    // const [userRooms, setUserRoom] = useState<IRoom[]>([]);
 
-    const { data } = useGetUserRooms(accessToken);
+    const { data: userRooms } = useGetUserRooms(accessToken);
 
-    useEffect(() => {
-        if (data) {
-            setUserRoom(data);
-        }
-    }, [data]);
+    // useEffect(() => {
+    //     if (data) {
+    //         setUserRoom(data);
+    //     }
+    // }, [data]);
 
     return (
         <>
@@ -33,7 +33,7 @@ const Lobby = () => {
                 </button>
             </header>
             <main className={style.main}>
-                {userRooms.length === 0 && (
+                {!userRooms?.length && (
                     <div className={style.no_room_container}>
                         <p className={style.title}>
                             오른쪽 상단의 버튼을 클릭해 방을 개설해 보세요!
@@ -41,7 +41,7 @@ const Lobby = () => {
                     </div>
                 )}
 
-                {userRooms.length > 0 && (
+                {userRooms && userRooms.length > 0 && (
                     <div className={style.room_container}>
                         <h2 className={style.title}>내가 만든 방들</h2>
                         <p className={style.description}>
@@ -51,7 +51,7 @@ const Lobby = () => {
                             새로운 방을 만들고 싶다면 화면의 오른쪽 상단에 있는 버튼을 클릭하세요.
                         </p>
                         <ul className={style.room_cards}>
-                            {userRooms.map((room: IRoom) => {
+                            {userRooms?.map((room: IRoom) => {
                                 return (
                                     <li key={room.id}>
                                         <RoomCard room={room} />

--- a/client/src/modules/fetchClient.ts
+++ b/client/src/modules/fetchClient.ts
@@ -38,11 +38,18 @@ export class FetchClient {
         return this.request<T>(path, { ...config, method: "PATCH", body: requestBody });
     }
 
-    private async request<T>(path: string, config: RequestInit): Promise<T> {
+    protected async request<T>(path: string, config: RequestInit): Promise<T> {
         const url = this.baseURL + path;
+
+        const headers = {
+            ...this.config.headers,
+            ...config.headers,
+        };
+
         const requestConfig: RequestInit = {
             ...this.config,
             ...config,
+            headers,
         };
 
         try {
@@ -74,3 +81,17 @@ export const baseClient = FetchClient.create({
         credentials: "include",
     },
 });
+
+export const addAuthHeader = (accessToken: string, config: RequestInit = {}) => {
+    if (!accessToken) {
+        throw new Error("access token이 없거나 올바르지 않습니다.");
+    }
+
+    return {
+        ...config,
+        headers: {
+            ...config.headers,
+            Authorization: `Bearer ${accessToken}`,
+        },
+    };
+};


### PR DESCRIPTION
## 개요
fetchClient 버그 해결


## 작업 사항
* 기존 fetchClient에서 추가적으로 config 설정을 하게되면 기존꺼에서 추가되는 형식이 아니라 덮어씌워지는 형식이라 baseClient headers에 설정해 놓은 "Content-Type": "application/json" 이 부분이 없어지게 되어서 POST 나 PATCH가 되지 않았던것 같습니다.

* addAuthHeader 라는 토큰값 검증과 토큰 관련 헤더추가하는 함수 작성.


## 리뷰 요청 사항
* page.tsx 파일에서 useQuery 리턴한 값을 다시 useEffect를 사용해서 상태안에 그대로 넣어주고있는데 혹시 그냥 사용하시는 건 별로일까요?
* room.repository에서 토큰 헤더 추가하는것과 토큰 검증하는 코드를 하나만 바꿔놨는데 저렇게 하는거 괜찮으시다면 주석지우고 나머지도 바꿔놓겠습니다.