### PR TITLE
fix: room 소켓 연결/해제 시 DB에 저장/삭제 정상화

### DIFF
--- a/client/src/app/room/[roomId]/hooks/useChatSocket.ts
+++ b/client/src/app/room/[roomId]/hooks/useChatSocket.ts
@@ -1,7 +1,7 @@
+import { useEffect, useState } from "react";
 import { useGetUserInfo } from "@/app/api/service/user.service";
 import { roomSocket } from "@/socket";
 import { IRoomUser, IMessage } from "@/types/chat";
-import { useEffect, useState } from "react";
 
 interface Params {
     roomId: string;
@@ -30,6 +30,10 @@ const useChatSocket = (params: Params) => {
 
     useEffect(() => {
         if (!user || !roomId) return;
+
+        if (!roomSocket.connected) {
+            roomSocket.connect();
+        }
 
         roomSocket.emit("join_room", { roomId, userId: user.userId, userName: user.userName });
         roomSocket.on("new_message", handleNewMessage);

--- a/client/src/socket.ts
+++ b/client/src/socket.ts
@@ -2,4 +2,8 @@ import { io } from "socket.io-client";
 
 const URL = process.env.NEXT_PUBLIC_SERVER_URL;
 
-export const roomSocket = io(`${URL}/room`, { autoConnect: true, withCredentials: true, transports: ["websocket", "polling"]  });
+export const roomSocket = io(`${URL}/room`, {
+    autoConnect: false,
+    withCredentials: true,
+    transports: ["websocket", "polling"],
+});

--- a/server/src/rooms/rooms.gateway.ts
+++ b/server/src/rooms/rooms.gateway.ts
@@ -11,7 +11,6 @@ import {
 } from "@nestjs/websockets";
 import { Types } from "mongoose";
 import { Server, Socket } from "socket.io";
-import { Types } from "mongoose";
 import { RoomsService } from "src/rooms/rooms.service";
 import { MessageInfoDTO } from "./dto/messageInfo.dto";
 import { TimerDto } from "./dto/timer.dto";

--- a/server/src/rooms/rooms.service.ts
+++ b/server/src/rooms/rooms.service.ts
@@ -74,7 +74,11 @@ export class RoomsService {
 
     async removeUserFromRoom(roomId: string, removeUserId: Types.ObjectId) {
         const updatedRoom = await this.roomModel
-            .findOneAndUpdate({ _id: roomId }, { $pull: { userIds: removeUserId } }, { new: true })
+            .findOneAndUpdate(
+                { _id: roomId },
+                { $pull: { userIds: { _id: new Types.ObjectId(removeUserId) } } },
+                { new: true },
+            )
             .exec();
 
         if (!updatedRoom) {


### PR DESCRIPTION
## 개요
<!-- 한 줄 정도로 어떤 PR인지 설명해주세요 -->
사용자가 방에 들어오는 경우 DB에 저장 정상화, 방에서 나가는 경우 DB에서 삭제 정상화하였습니다.

## 작업 사항
<!-- 가능하다면 스크린샷을 첨부해주세요 -->
### 방에 입장
1. 최근 피알 #45 을 pull 하고 확인하니, 소켓 관련 움직임이 없어도 방에 입장하자마자 소켓 및 DB에 저장 정상
2. 그런데 방에서 <뒤로 가기>를 통해 다시 로비로 간 후,
3. 다시 방에 접속하면 소켓과 연관된 것들이 작동하지 않음

**=> room 소켓 자동 연결 문제로, 자동 연결을 true -> `false`로 바꾼 뒤, 소켓 연결을 useChatSocket에서 하도록 처리**

### 방에서 퇴장
방에서 나가면 DB에서 삭제가 되지 않았던 원인은 삭제하는 함수가 잘못되어서였습니다^^..
삭제하는 함수를 올바르게 바꿨습니다!
그리고 삭제할 때는 MongoDB가 정확한 타입(ObjectId)을 요구해 함수 내에서 바꿔주도록 했습니다
<br><br>
