### PR TITLE
fix: 방 이름 변경 후 재변경 시 즉시 반영되지 않던 문제 수정, 없는 방 진입 처리, not-found 추가, 없어야 할 코드 제거

### DIFF
--- a/client/src/apis/repository/room.repository.ts
+++ b/client/src/apis/repository/room.repository.ts
@@ -1,5 +1,5 @@
-import { addAuthHeader, baseClient, createAuthHeader } from "@/modules/fetchClient";
-import { ICreateRoomResponse, IPatchRoom } from "@/types/room.type";
+import { baseClient, createAuthHeader } from "@/modules/fetchClient";
+import { IRoomModel, IPatchRoom } from "@/types/room.type";
 
 export const getRoomInfo = async (roomId: string, accessToken?: string) => {
     const headers = createAuthHeader(accessToken);
@@ -16,7 +16,7 @@ export const getUserRooms = async (accessToken?: string) => {
 };
 
 export const createRoom = async (roomNameInput: string) => {
-    return await baseClient.post<ICreateRoomResponse>("/rooms", {
+    return await baseClient.post<IRoomModel>("/rooms", {
         roomData: { roomName: roomNameInput },
     });
 };

--- a/client/src/apis/service/room.service.ts
+++ b/client/src/apis/service/room.service.ts
@@ -46,7 +46,7 @@ export const useGetRoomData = (roomId: string) => {
     return useQuery({ queryKey: QUERY_KEY.room(roomId), queryFn: formatRoomData });
 };
 
-export const usePatchRoomData = () => {
+export const usePatchRoomData = (roomId: string) => {
     const queryClient = useQueryClient();
     const formatRoomData = async ({ roomName, roomId }: IPatchRoom) => {
         const res = (await patchRoom({ roomName, roomId })) as IRoomModel;
@@ -61,9 +61,8 @@ export const usePatchRoomData = () => {
     return useMutation({
         mutationFn: formatRoomData,
         onSuccess: () => {
-            queryClient.invalidateQueries({
-                queryKey: QUERY_KEY.rooms,
-            });
+            queryClient.invalidateQueries({ queryKey: QUERY_KEY.rooms });
+            queryClient.refetchQueries({ queryKey: QUERY_KEY.room(roomId) });
         },
     });
 };

--- a/client/src/apis/service/room.service.ts
+++ b/client/src/apis/service/room.service.ts
@@ -8,7 +8,6 @@ import {
 } from "../repository/room.repository";
 import { IPatchRoom, IRoomModel } from "@/types/room.type";
 import { QUERY_KEY } from "@/constants/queryKey.const";
-import { IUser } from "@/types/user.type";
 
 interface ICreateRoom {
     roomNameInput: string;
@@ -25,7 +24,7 @@ export const useCreateRoom = () => {
         };
     };
 
-    return useMutation({ 
+    return useMutation({
         mutationFn: formatRoomData,
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: QUERY_KEY.rooms });
@@ -41,14 +40,6 @@ export const useGetRoomData = (roomId: string) => {
             roomName: res.room_name,
             admin: res.admin,
             createdAt: res.created_at,
-            userIds: res.userIds.map((user) => {
-                return {
-                    userName: user.user_name,
-                    userId: user._id,
-                    profileImg: user.profile_img,
-                    email: user.email,
-                } as IUser;
-            }),
         };
     };
 
@@ -70,7 +61,7 @@ export const usePatchRoomData = () => {
     return useMutation({
         mutationFn: formatRoomData,
         onSuccess: () => {
-            queryClient.invalidateQueries({ 
+            queryClient.invalidateQueries({
                 queryKey: QUERY_KEY.rooms,
             });
         },
@@ -84,7 +75,6 @@ export const formatRoomsData = async (accessToken?: string) => {
         roomName: room.room_name,
         admin: room.admin,
         createdAt: room.created_at,
-        userIds: room.userIds,
     }));
 };
 

--- a/client/src/apis/service/room.service.ts
+++ b/client/src/apis/service/room.service.ts
@@ -44,7 +44,7 @@ export const useGetRoomData = (roomId: string) => {
     };
 
     return useQuery({
-        queryKey: ["room", roomId],
+        queryKey: QUERY_KEY.room(roomId),
         queryFn: formatRoomData,
         retry: 0,
         staleTime: 1000 * 60 * 5,

--- a/client/src/apis/service/room.service.ts
+++ b/client/src/apis/service/room.service.ts
@@ -43,7 +43,16 @@ export const useGetRoomData = (roomId: string) => {
         };
     };
 
-    return useQuery({ queryKey: QUERY_KEY.room(roomId), queryFn: formatRoomData });
+    return useQuery({
+        queryKey: ["room", roomId],
+        queryFn: formatRoomData,
+        retry: 0,
+        staleTime: 1000 * 60 * 5,
+        cacheTime: 1000 * 60 * 10,
+        refetchOnWindowFocus: false,
+        enabled: !!roomId,
+        initialData: undefined,
+    });
 };
 
 export const usePatchRoomData = (roomId: string) => {

--- a/client/src/app/not-found.tsx
+++ b/client/src/app/not-found.tsx
@@ -3,7 +3,7 @@ import NotFound from "@/components/common/notFound/notFound";
 import { NOT_FOUND_MESSAGES } from "@/constants/notFound.const";
 
 const NotFoundPage = () => {
-    return <NotFound message={NOT_FOUND_MESSAGES.room} />;
+    return <NotFound message={NOT_FOUND_MESSAGES.global} />;
 };
 
 export default NotFoundPage;

--- a/client/src/app/room/[roomId]/not-found.module.scss
+++ b/client/src/app/room/[roomId]/not-found.module.scss
@@ -1,0 +1,25 @@
+@import "../../../styles/variables";
+
+.main {
+    position: relative;
+    height: 100vh;
+}
+
+.container {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    text-align: center;
+
+    .strong {
+        display: block;
+        margin: 20px 0px 15px 0px;
+        font-size: 18px;
+        font-weight: 700;
+        color: $warning-red;
+    }
+    .buttons {
+        margin-left: 79px;
+    }
+}

--- a/client/src/app/room/[roomId]/not-found.tsx
+++ b/client/src/app/room/[roomId]/not-found.tsx
@@ -1,0 +1,29 @@
+"use client";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+import Button from "@/components/common/button/button";
+import style from "./not-found.module.scss";
+
+const NotFound = () => {
+    const router = useRouter();
+
+    return (
+        <main className={style.main}>
+            <div className={style.container}>
+                <Image src="/favicon.ico" alt="MEETSIN 로고" width={90} height={90} />
+                <strong className={style.strong}>삭제되었거나 존재하지 않는 방입니다</strong>
+                <div className={style.buttons}>
+                    <Button
+                        type="button"
+                        onClick={() => router.push("/")}
+                        look="ghost"
+                        width={120}
+                        text="MEETSIN 홈"
+                        bold
+                    />
+                </div>
+            </div>
+        </main>
+    );
+};
+export default NotFound;

--- a/client/src/app/room/[roomId]/page.tsx
+++ b/client/src/app/room/[roomId]/page.tsx
@@ -2,17 +2,18 @@
 import { useEffect, useMemo, useState } from "react";
 import dynamic from "next/dynamic";
 import { useParams } from "next/navigation";
+import { notFound } from "next/navigation";
 import { useAtomValue } from "jotai";
 import { screenShareStateAtom } from "@/jotai/atom";
 import Chat from "@/components/chat/chat";
 import Menu from "@/components/menu/menu";
 import ScreenWindow from "@/components/screen/window/screenWindow";
 import Skeleton from "@/components/common/skeleton/skeleton";
+import ViewSwitchButton from "@/components/buttons/viewSwitch/viewSwitchButton";
+import RoomGradientBackground from "@/components/background/room/roomGradientBackground";
 import useChatSocket from "@/app/room/[roomId]/hooks/useChatSocket";
 import { useScreenShare } from "./hooks/useScreenShare";
-import ViewSwitchButton from "@/components/buttons/viewSwitch/viewSwitchButton";
 import { IScreenShareState } from "@/types/peer.type";
-import RoomGradientBackground from "@/components/background/room/roomGradientBackground";
 import { useGetRoomData } from "@/apis/service/room.service";
 import style from "./style.module.scss";
 
@@ -29,11 +30,15 @@ const Room = () => {
 
     const params = useParams();
     const roomId = params.roomId as string;
-    const { data } = useGetRoomData(roomId);
+    const { data, isError } = useGetRoomData(roomId);
 
     const { roomUsers, messages } = useChatSocket({ roomId });
     const { currentPeers, startScreenShare, stopScreenShare, setPeerId, setCurrentPeers } =
         useScreenShare(roomId);
+
+    if (isError) {
+        notFound();
+    }
 
     const toggleChat = (shouldClose?: boolean) => {
         setChatOpen((prev) => (shouldClose ? false : !prev));

--- a/client/src/app/style.module.scss
+++ b/client/src/app/style.module.scss
@@ -45,7 +45,7 @@
         justify-content: center;
         align-items: center;
         padding: 16px;
-        
+
         .make_room_description {
             font-weight: bold;
             font-size: 18px;
@@ -121,7 +121,6 @@
 }
 
 .carousel_image {
-    background-color: $point-color;
     width: 100%;
     height: 100%;
     object-fit: cover;
@@ -178,7 +177,8 @@
     background-color: $white;
     opacity: 40%;
 
-    &:hover, &.active {
+    &:hover,
+    &.active {
         opacity: 100%;
         cursor: pointer;
         transition: opacity 0.3s ease-in-out;

--- a/client/src/components/common/notFound/notFound.module.scss
+++ b/client/src/components/common/notFound/notFound.module.scss
@@ -20,6 +20,7 @@
         color: $warning-red;
     }
     .buttons {
-        margin-left: 79px;
+        display: flex;
+        justify-content: center;
     }
 }

--- a/client/src/components/common/notFound/notFound.tsx
+++ b/client/src/components/common/notFound/notFound.tsx
@@ -1,0 +1,35 @@
+"use client";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+import Button from "@/components/common/button/button";
+import { NOT_FOUND_MESSAGES_TYPE } from "@/constants/notFound.const";
+import style from "./notFound.module.scss";
+
+interface INotFoundProps {
+    message: NOT_FOUND_MESSAGES_TYPE;
+}
+
+const NotFound = ({ message }: INotFoundProps) => {
+    const router = useRouter();
+
+    return (
+        <main className={style.main}>
+            <div className={style.container}>
+                <Image src="/favicon.ico" alt="MEETSIN 로고" width={90} height={90} />
+                <strong className={style.strong}>{message}</strong>
+                <div className={style.buttons}>
+                    <Button
+                        type="button"
+                        onClick={() => router.push("/")}
+                        look="ghost"
+                        width={120}
+                        text="MEETSIN 홈"
+                        bold
+                    />
+                </div>
+            </div>
+        </main>
+    );
+};
+
+export default NotFound;

--- a/client/src/components/modals/renameRoom/renameRoom.tsx
+++ b/client/src/components/modals/renameRoom/renameRoom.tsx
@@ -16,7 +16,7 @@ const RenameRoom = ({ onClose }: IModal) => {
 
     const { data } = useGetRoomData(roomId);
 
-    const { mutate } = usePatchRoomData();
+    const { mutate } = usePatchRoomData(roomId);
 
     const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();

--- a/client/src/constants/notFound.const.ts
+++ b/client/src/constants/notFound.const.ts
@@ -1,0 +1,6 @@
+export const NOT_FOUND_MESSAGES = {
+    global: "존재하지 않는 페이지입니다",
+    room: "삭제되었거나 존재하지 않는 방입니다",
+} as const;
+
+export type NOT_FOUND_MESSAGES_TYPE = (typeof NOT_FOUND_MESSAGES)[keyof typeof NOT_FOUND_MESSAGES];

--- a/client/src/types/room.type.ts
+++ b/client/src/types/room.type.ts
@@ -1,11 +1,8 @@
-import { IUser, IUserModel } from "./user.type";
-
 export interface IRoom {
     id: string;
     roomName: string;
     admin: string;
     createdAt: string;
-    userIds: IUserModel[];
 }
 
 export interface IRoomModel {
@@ -13,18 +10,9 @@ export interface IRoomModel {
     room_name: string;
     admin: string;
     created_at: string;
-    userIds: IUserModel[];
 }
 
 export interface IPatchRoom {
     roomName: string;
     roomId: string;
-}
-
-export interface ICreateRoomResponse {
-    room_name: string;
-    admin: string;
-    userIds: string[];
-    _id: string;
-    created_at: string;
 }

--- a/server/src/modules/rooms/schemas/rooms.schema.ts
+++ b/server/src/modules/rooms/schemas/rooms.schema.ts
@@ -1,5 +1,4 @@
 import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
-import { User } from "src/modules/users/schemas/user.schema";
 
 const options = {
     collection: "Rooms",
@@ -14,9 +13,6 @@ export class Room {
 
     @Prop({ required: true })
     admin: string;
-
-    @Prop({ required: true })
-    userIds: User[];
 }
 
 export const RoomSchema = SchemaFactory.createForClass(Room);


### PR DESCRIPTION
## 개요
<!-- 한 줄 정도로 어떤 PR인지 설명해주세요 -->
- 방 이름 변경한 후 재변경 시 즉시 반영되지 않던 문제 수정
- 없는 방 진입 시 notFound 페이지 띄움
- notFound 컴포넌트 생성
- 전역, room 페이지에 not-found 페이지 생성

그밖에 없어야 하는 코드들 제거 하였습니다.

## 작업 사항
- 방 이름 변경 후, 또 변경 버튼 누르는 경우 모달에 바뀐 이름 바로 반영되지 않던 문제 수정
- notFound 컴포넌트 생성
- app/room/[roomId] 경로에 `not-found.tsx` 생성 후 없는 방 진입 시 띄움 (피그마에서 not-found 이미지 확인 가능)
- 전역 not-found 생성

제거 ⬇
- 코드에 남은 userIds 배열 제거 (room DB에 저장되던)
- IRoomModel과 중복되던 ICreateRoomResponse 인터페이스 제거
- 랜딩 페이지의 캐러셀 이미지 배경색 제거


## 리뷰 요청 사항
