### PR TITLE
fix: 액세스 토큰 대신 리프레시 토큰 사용하도록 수정

### DIFF
--- a/client/src/apis/repository/room.repository.ts
+++ b/client/src/apis/repository/room.repository.ts
@@ -2,17 +2,11 @@ import { baseClient, createAuthHeader } from "@/modules/fetchClient";
 import { PatchRoom, RoomModel } from "@/types/room.type";
 
 export const getRoomInfo = async (roomId: string, accessToken?: string) => {
-    const headers = createAuthHeader(accessToken);
-
-    return await baseClient.get<RoomModel>(`/rooms/${roomId}`, { headers });
+    return await baseClient.get<RoomModel>(`/rooms/${roomId}`);
 };
 
-export const getUserRooms = async (accessToken?: string) => {
-    const headers = createAuthHeader(accessToken);
-
-    return await baseClient.get<RoomModel[]>("/rooms/user", {
-        headers,
-    });
+export const getUserRooms = async () => {
+    return await baseClient.get<RoomModel[]>("/rooms/user");
 };
 
 export const createRoom = async (roomNameInput: string) => {

--- a/client/src/apis/repository/user.repository.ts
+++ b/client/src/apis/repository/user.repository.ts
@@ -1,14 +1,14 @@
-import { baseClient, createAuthHeader } from "@/modules/fetchClient";
+import { baseClient } from "@/modules/fetchClient";
 import { UserModel } from "@/types/user.type";
 
 export const getUserInfo = async (accessToken?: string) => {
-    const headers = createAuthHeader(accessToken);
-
-    return await baseClient.get<UserModel>("/auth/user", {
-        headers,
-    });
+    return await baseClient.get<UserModel>("/auth/user");
 };
 
 export const logout = async () => {
     return await baseClient.post<void>("/auth/logout");
+};
+
+export const refreshToken = async () => {
+    return await baseClient.post<{ access_token: string }>("/auth/refresh");
 };

--- a/client/src/apis/service/room.service.ts
+++ b/client/src/apis/service/room.service.ts
@@ -76,8 +76,8 @@ export const usePatchRoomData = (roomId: string) => {
     });
 };
 
-export const formatRoomsData = async (accessToken?: string) => {
-    const { data } = (await getUserRooms(accessToken)) as { data: RoomModel[] };
+export const formatRoomsData = async () => {
+    const { data } = (await getUserRooms()) as { data: RoomModel[] };
     return data.map((room) => ({
         id: room._id,
         roomName: room.room_name,
@@ -86,8 +86,8 @@ export const formatRoomsData = async (accessToken?: string) => {
     }));
 };
 
-export const useGetUserRooms = (accessToken?: string) => {
-    return useQuery({ queryKey: QUERY_KEY.rooms, queryFn: () => formatRoomsData(accessToken) });
+export const useGetUserRooms = () => {
+    return useQuery({ queryKey: QUERY_KEY.rooms, queryFn: () => formatRoomsData() });
 };
 
 export const useDeleteRoom = (roomId: string) => {

--- a/client/src/apis/service/user.service.ts
+++ b/client/src/apis/service/user.service.ts
@@ -1,7 +1,9 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { getUserInfo, logout } from "../repository/user.repository";
+import { getUserInfo, logout, refreshToken } from "../repository/user.repository";
 import { User } from "@/types/user.type";
 import { QUERY_KEY } from "@/constants/queryKey.const";
+import { accessTokenAtom } from "@/jotai/atom";
+import { useSetAtom } from "jotai";
 
 export const useGetUserInfo = () => {
     return useQuery({
@@ -22,6 +24,17 @@ export const useLogout = () => {
     return useMutation({
         mutationFn: async () => {
             await logout();
+        },
+    });
+};
+
+export const useRefreshToken = () => {
+    const setAccessToken = useSetAtom(accessTokenAtom);
+    return useMutation({
+        mutationFn: () => refreshToken(),
+        onSuccess: ({ data }) => {
+            const accessToken = data.access_token;
+            setAccessToken(accessToken);
         },
     });
 };

--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -8,6 +8,7 @@ import MsClarity from "./msClarity";
 import "../styles/reset.css";
 import "../styles/global.scss";
 import { GoogleAnalytics } from "./googleAnalytics";
+import { RefreshProvider } from "./refreshProvider";
 
 const noto_Sans_KR = Noto_Sans_KR({ weight: ["400", "700"], subsets: ["latin"] });
 
@@ -51,7 +52,7 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
                 <NewQueryProviders>
                     <JotaiProvider>
                         <ModalProvider>
-                            {children}
+                            <RefreshProvider>{children}</RefreshProvider>
                             <MsClarity />
                         </ModalProvider>
                     </JotaiProvider>

--- a/client/src/app/lobby/page.tsx
+++ b/client/src/app/lobby/page.tsx
@@ -1,9 +1,5 @@
 import LobbyHeader from "@/components/lobby/lobbyHeader/lobbyHeader";
 import LobbyMain from "@/components/lobby/lobbyMain/lobbyMain";
-import { QUERY_KEY } from "@/constants/queryKey.const";
-import { HydrationBoundary, QueryClient, dehydrate } from "@tanstack/react-query";
-import { getToken } from "@/utils/getToken.utill";
-import { formatRoomsData } from "../../apis/service/room.service";
 import { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -11,20 +7,11 @@ export const metadata: Metadata = {
 };
 
 const Lobby = async () => {
-    const queryClient = new QueryClient();
-
-    const accessToken = getToken();
-
-    await queryClient.prefetchQuery({
-        queryKey: QUERY_KEY.rooms,
-        queryFn: () => formatRoomsData(accessToken),
-    });
-
     return (
-        <HydrationBoundary state={dehydrate(queryClient)}>
+        <>
             <LobbyHeader />
             <LobbyMain />
-        </HydrationBoundary>
+        </>
     );
 };
 

--- a/client/src/app/refreshProvider.tsx
+++ b/client/src/app/refreshProvider.tsx
@@ -1,0 +1,23 @@
+"use client";
+import { PropsWithChildren, useEffect } from "react";
+import { useSetAtom } from "jotai";
+import { accessTokenAtom } from "@/jotai/atom";
+import { refreshToken } from "@/apis/repository/user.repository";
+
+export function RefreshProvider({ children }: PropsWithChildren) {
+    const setAccessToken = useSetAtom(accessTokenAtom);
+
+    useEffect(() => {
+        (async () => {
+            try {
+                const { data } = await refreshToken();
+                setAccessToken(data.access_token);
+            } catch {
+                // 무시 or 로그인 페이지로 리다이렉트
+                console.error("리프레시 토큰 요청에 실패했습니다.");
+            }
+        })();
+    }, [setAccessToken]);
+
+    return children;
+}

--- a/client/src/jotai/atom.ts
+++ b/client/src/jotai/atom.ts
@@ -28,3 +28,5 @@ export const roomIdAtom = atom("");
 export const isChatFocusedAtom = atom(false);
 
 export const zoomLevelAtom = atom(MIN_ZOOM_LEVEL);
+
+export const accessTokenAtom = atom<string | null>(null);

--- a/client/src/middleware.ts
+++ b/client/src/middleware.ts
@@ -9,9 +9,9 @@ const publicUrls: Routes = {
 };
 
 export async function middleware(request: NextRequest) {
-    const accessToken = request.cookies.get("access_token");
+    const refreshToken = request.cookies.get("refresh_token");
     const exists = publicUrls[request.nextUrl.pathname];
-    if (!accessToken) {
+    if (!refreshToken) {
         if (!exists) {
             return NextResponse.redirect(new URL("/", request.url));
         }

--- a/client/src/utils/getToken.utill.ts
+++ b/client/src/utils/getToken.utill.ts
@@ -1,14 +1,16 @@
-import { cookies } from "next/headers";
+import { refreshToken } from "@/apis/repository/user.repository";
+import { accessTokenAtom } from "@/jotai/atom";
+import { getDefaultStore } from "jotai";
 
-export const getToken = () => {
+export const getToken = async () => {
     // 서버 사이드에서 실행
     if (typeof window === "undefined") {
-        return cookies().get("access_token")?.value;
+        const { data } = await refreshToken();
+        const accessToken = data.access_token;
+        return accessToken;
     }
-    
+
     // 클라이언트 사이드에서 실행
-    return document.cookie
-        .split("; ")
-        .find((row) => row.startsWith("access_token="))
-        ?.split("=")[1];
+    const store = getDefaultStore();
+    return store.get(accessTokenAtom);
 };

--- a/server/src/common/guards/auth.guard.ts
+++ b/server/src/common/guards/auth.guard.ts
@@ -3,75 +3,27 @@ import { ExecutionContext, Injectable, UnauthorizedException } from "@nestjs/com
 import { JwtService } from "@nestjs/jwt";
 import { AuthGuard } from "@nestjs/passport";
 
-// @Injectable()
-// export class JwtGuard extends AuthGuard("jwt") {
-//     constructor(private usersRepository: UsersRepository, private jwtService: JwtService) {
-//         super();
-//     }
-//     async canActivate(context: ExecutionContext) {
-//         const req = context.switchToHttp().getRequest();
-//         const { authorization } = req.headers;
-//         if (!authorization) {
-//             throw new UnauthorizedException("Authorization 요청 헤더를 추가해주세요");
-//         }
-//         const token = authorization.replace("Bearer ", "");
-//         const userInfoByToken = await this.validateToken(token);
-//         if (!userInfoByToken.id) {
-//             throw new UnauthorizedException("token is not valid");
-//         }
-//         const user = await this.usersRepository.findUserById(userInfoByToken.id);
-//         req.user = user;
-//         return true;
-//     }
-
-//     async validateToken(token) {
-//         const isValid = await this.jwtService.verify(token, {
-//             secret: process.env.JWT_SECRET,
-//         });
-//         return isValid;
-//     }
-// }
-
 @Injectable()
 export class JwtGuard extends AuthGuard("jwt") {
-    constructor(private usersRepository: UsersRepository, private jwtService: JwtService) {
-        super();
-    }
-    async canActivate(context: ExecutionContext) {
-        const req = context.switchToHttp().getRequest();
-        const token =
-            req.cookies["access_token"] || req.headers["authorization"]?.replace("Bearer ", "");
-
-        if (!token) {
-            throw new UnauthorizedException("Authorization 요청 헤더를 추가해주세요");
-        }
-        const userInfoByToken = await this.validateToken(token);
-
-        if (!userInfoByToken.id) {
-            throw new UnauthorizedException("유효한 토큰이 아닙니다.");
-        }
-
-        const user = await this.usersRepository.findUserById(userInfoByToken.id);
-        req.user = user;
-        return true;
-    }
-
-    async validateToken(token) {
-        try {
-            // 게스트 토큰인 경우 만료 검사 건너뛰기
-            if (token === process.env.GUEST_ACCESS_TOKEN) {
-                return this.jwtService.decode(token);
-            }
-
-            const isValid = await this.jwtService.verify(token, {
-                secret: process.env.JWT_SECRET,
-            });
-            return isValid;
-        } catch (error) {
-            if (error?.name === "TokenExpiredError") {
+    handleRequest(err, user, info) {
+        if (err || !user) {
+            if (info?.name === "TokenExpiredError") {
                 throw new UnauthorizedException("토큰이 만료되었습니다.");
             }
             throw new UnauthorizedException("유효하지 않은 토큰입니다.");
         }
+        return user;
+    }
+}
+
+export class JwtRefreshGuard extends AuthGuard("jwt-refresh") {
+    handleRequest(err, user, info) {
+        if (err || !user) {
+            if (info?.name === "TokenExpiredError") {
+                throw new UnauthorizedException("리프레시 토큰이 만료되었습니다.");
+            }
+            throw new UnauthorizedException("유효하지 않은 리프레시 토큰입니다.");
+        }
+        return user;
     }
 }

--- a/server/src/modules/auth/auth.module.ts
+++ b/server/src/modules/auth/auth.module.ts
@@ -4,7 +4,7 @@ import { ConfigModule } from "@nestjs/config";
 import { UsersModule } from "src/modules/users/users.module";
 import { KakaoStrategy } from "./strategies/kakao.strategy";
 import { GoogleStrategy } from "./strategies/google.strategy";
-import { JwtStrategy } from "./strategies/jwt.strategy";
+import { JwtRefreshStrategy, JwtStrategy } from "./strategies/jwt.strategy";
 import { AuthController } from "./auth.controller";
 import dotenv from "dotenv";
 import { JwtModule } from "@nestjs/jwt";
@@ -34,11 +34,24 @@ dotenv.config();
         JwtModule.register({
             secret: process.env.JWT_SECRET,
             signOptions: {
+                expiresIn: "15m",
+            },
+        }),
+        JwtModule.register({
+            secret: process.env.JWT_REFRESH_SECRET,
+            signOptions: {
                 expiresIn: "30d",
             },
         }),
     ],
-    providers: [AuthService, UsersService, GoogleStrategy, KakaoStrategy, JwtStrategy],
+    providers: [
+        AuthService,
+        UsersService,
+        GoogleStrategy,
+        KakaoStrategy,
+        JwtStrategy,
+        JwtRefreshStrategy,
+    ],
     controllers: [AuthController],
     exports: [AuthService],
 })

--- a/server/src/modules/auth/strategies/jwt.strategy.ts
+++ b/server/src/modules/auth/strategies/jwt.strategy.ts
@@ -31,10 +31,7 @@ export class JwtStrategy extends PassportStrategy(Strategy, "jwt") {
         if (!user) {
             throw new UnauthorizedException("유효하지 않은 토큰입니다.");
         }
-        return {
-            id: payload.id,
-            email: payload.email,
-        };
+        return user;
     }
 }
 

--- a/server/src/modules/auth/strategies/jwt.strategy.ts
+++ b/server/src/modules/auth/strategies/jwt.strategy.ts
@@ -1,20 +1,54 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, UnauthorizedException } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { PassportStrategy } from "@nestjs/passport";
-import { request } from "express";
 import { ExtractJwt, Strategy } from "passport-jwt";
 import dotenv from "dotenv";
 import { JwtPayload } from "jsonwebtoken";
+import { UsersRepository } from "src/modules/users/users.repository";
 
 dotenv.config();
 
 @Injectable()
-export class JwtStrategy extends PassportStrategy(Strategy) {
-    constructor(private readonly config: ConfigService) {
+export class JwtStrategy extends PassportStrategy(Strategy, "jwt") {
+    constructor(
+        private readonly configService: ConfigService,
+        private readonly usersRepository: UsersRepository,
+    ) {
         super({
-            jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+            jwtFromRequest: ExtractJwt.fromExtractors([
+                (request) => {
+                    return request?.cookies["access_token"];
+                },
+                ExtractJwt.fromAuthHeaderAsBearerToken(),
+            ]),
             ignoreExpiration: false,
-            secretOrKey: process.env.JWT_SECRET,
+            secretOrKey: configService.get("JWT_SECRET"),
+        });
+    }
+
+    async validate(payload: JwtPayload) {
+        const user = await this.usersRepository.findUserById(payload.id);
+        if (!user) {
+            throw new UnauthorizedException("유효하지 않은 토큰입니다.");
+        }
+        return {
+            id: payload.id,
+            email: payload.email,
+        };
+    }
+}
+
+@Injectable()
+export class JwtRefreshStrategy extends PassportStrategy(Strategy, "jwt-refresh") {
+    constructor(private readonly configService: ConfigService) {
+        super({
+            jwtFromRequest: ExtractJwt.fromExtractors([
+                (request) => {
+                    return request?.cookies["refresh_token"];
+                },
+            ]),
+            ignoreExpiration: false,
+            secretOrKey: configService.get("JWT_REFRESH_SECRET"),
         });
     }
 

--- a/server/src/modules/users/schemas/user.schema.ts
+++ b/server/src/modules/users/schemas/user.schema.ts
@@ -1,7 +1,7 @@
-import { OmitType } from "@nestjs/mapped-types";
 import { Prop, Schema, SchemaFactory, SchemaOptions } from "@nestjs/mongoose";
 import { Document, Schema as MongooseSchema } from "mongoose";
 import { Subscription } from "src/modules/notification/schema/subscription.schema";
+import { Transform } from "class-transformer";
 
 const options: SchemaOptions = {
     timestamps: true,
@@ -9,9 +9,34 @@ const options: SchemaOptions = {
     versionKey: false,
 };
 
+export interface IUser extends Document {
+    _id: string | MongooseSchema.Types.ObjectId;
+    user_name: string;
+    email: string;
+    character?: string;
+    profile_img: string;
+    access_token: string;
+    refresh_token: string;
+    provider: string;
+    notification?: Subscription;
+}
+
+// 회원가입 시 받게 되는 소셜 유저 정보
+export interface INewUser {
+    id: string;
+    email: string;
+    user_name: string;
+    profile_img: string;
+    access_token: string;
+    refresh_token: string;
+}
+
 // DB에 저장되는 유저 정보 (토큰 포함)
 @Schema(options)
-export class User extends Document {
+export class User extends Document implements IUser {
+    @Transform(({ obj }) => obj._id.toString())
+    _id: string | MongooseSchema.Types.ObjectId;
+
     @Prop({
         required: true,
     })
@@ -42,6 +67,13 @@ export class User extends Document {
 }
 
 // 클라이언트에 제공되는 유저 정보 (토큰 미포함)
-export class UserDto extends OmitType(User, ["access_token", "refresh_token"]) {}
+export class UserDto {
+    _id: string;
+    user_name: string;
+    email: string;
+    character?: string;
+    profile_img: string;
+    provider: string;
+}
 
 export const UserSchema = SchemaFactory.createForClass(User);

--- a/server/src/modules/users/users.repository.ts
+++ b/server/src/modules/users/users.repository.ts
@@ -27,7 +27,10 @@ export class UsersRepository {
         return await this.userModel.create(userData);
     }
 
-    async updateAccessToken(user: User, accessToken: string) {
-        await this.userModel.findByIdAndUpdate(user.id, { access_token: accessToken });
+    async updateTokens(user: User, accessToken: string, refreshToken: string) {
+        await this.userModel.findByIdAndUpdate(user.id, { 
+            access_token: accessToken,
+            refresh_token: refreshToken 
+        });
     }
 }

--- a/server/src/modules/users/users.service.ts
+++ b/server/src/modules/users/users.service.ts
@@ -1,19 +1,19 @@
 import { Injectable } from "@nestjs/common";
 import { UserDto, User } from "src/modules/users/schemas/user.schema";
 import { UsersRepository } from "./users.repository";
+import { plainToClass } from "class-transformer";
 
 @Injectable()
 export class UsersService {
     constructor(private readonly usersRepository: UsersRepository) {}
-
-    entityToDto(user: User) {
-        const userDto = new UserDto();
-        userDto._id = user._id;
-        userDto.email = user.email;
-        userDto.user_name = user.user_name;
-        userDto.profile_img = user.profile_img;
-        userDto.character = user.character;
-        userDto.provider = user.provider;
-        return userDto;
+    entityToDto(user: User): UserDto {
+        return plainToClass(UserDto, {
+            _id: user._id.toString(),
+            email: user.email,
+            user_name: user.user_name,
+            profile_img: user.profile_img,
+            character: user.character,
+            provider: user.provider,
+        });
     }
 }


### PR DESCRIPTION
## 개요
- 액세스 토큰 대신 리프레시 토큰 사용하도록 수정


## 작업 사항
백엔드
- 로그인 api 수정 ->쿠키에 액세스 토큰 대신 리프레시 토큰 저장
- /auth/refresh api 추가 -> 리프레시 토큰으로 액세스 토큰 재발급
- 회원가입/로그인 시 각 유저 정보 안의 id/_id 타입 에러 수정

프론트엔드
- 로그인 판별을 리프레시 토큰 여부로 수정 및 페이지 진입 시 리프레시 토큰으로 액세스 토큰 자동으로 재발급하여 jotai 아톰에 저장
- 기존 bearer token 보내던 동작 수정 -> repository에서 담는 게 아닌 fetchClient 안에서 담아서 보내도록


## 리뷰 요청 사항
- 개발 환경에서는 동작하는 거 확인하였으나 운영에서는 어떤 문제가 생길지 몰라서 조심스럽네요 테스트해보시려면 쿠키 옵션에서 httpOnly: true 지우시면 됩니다