### PR TITLE
fix: generateMetadata 시 리프레시 토큰 동작 수정

### DIFF
--- a/client/next.config.js
+++ b/client/next.config.js
@@ -15,6 +15,9 @@ const nextConfig = {
     typescript: {
         ignoreBuildErrors: true,
     },
+    experimental: {
+        serverActions: true,
+    },
 };
 
 module.exports = nextConfig;

--- a/client/src/apis/repository/room.repository.ts
+++ b/client/src/apis/repository/room.repository.ts
@@ -1,8 +1,11 @@
-import { baseClient, createAuthHeader } from "@/modules/fetchClient";
+import { baseClient } from "@/modules/fetchClient";
 import { PatchRoom, RoomModel } from "@/types/room.type";
 
-export const getRoomInfo = async (roomId: string, accessToken?: string) => {
-    return await baseClient.get<RoomModel>(`/rooms/${roomId}`);
+export const getRoomInfo = async (roomId: string, config?: RequestInit) => {
+    return await baseClient.get<RoomModel>(`/rooms/${roomId}`, {
+        ...config,
+        credentials: 'include',
+    });
 };
 
 export const getUserRooms = async () => {

--- a/client/src/apis/repository/user.repository.server.ts
+++ b/client/src/apis/repository/user.repository.server.ts
@@ -1,0 +1,16 @@
+"use server";
+
+import { baseClient } from "@/modules/fetchClient";
+import { headers } from "next/headers";
+
+export const refreshToken = async (config: { headers?: HeadersInit } = {}) => {
+    const headersList = headers();
+    const cookie = headersList.get("cookie");
+
+    return await baseClient.post<{ access_token: string }>("/auth/refresh", undefined, {
+        headers: {
+            cookie: cookie || "",
+        },
+        credentials: "include",
+    });
+};

--- a/client/src/apis/repository/user.repository.ts
+++ b/client/src/apis/repository/user.repository.ts
@@ -9,6 +9,9 @@ export const logout = async () => {
     return await baseClient.post<void>("/auth/logout");
 };
 
-export const refreshToken = async () => {
-    return await baseClient.post<{ access_token: string }>("/auth/refresh");
+export const refreshToken = async (config?: { headers?: HeadersInit }) => {
+    return await baseClient.post<{ access_token: string }>("/auth/refresh", undefined, {
+        headers: config?.headers,
+        credentials: "include",
+    });
 };

--- a/client/src/app/room/[roomId]/layout.tsx
+++ b/client/src/app/room/[roomId]/layout.tsx
@@ -1,14 +1,22 @@
+import React from "react";
 import { Metadata } from "next";
 import { getRoomInfo } from "@/apis/repository/room.repository";
-import { getToken } from "@/utils/getToken.utill";
+import { refreshToken } from "@/apis/repository/user.repository.server";
 
 interface Props {
     params: { roomId: string };
 }
 
 export const generateMetadata = async ({ params }: Props): Promise<Metadata> => {
-    const accessToken = getToken();
-    const { data: roomData } = await getRoomInfo(params.roomId, accessToken);
+    const {
+        data: { access_token },
+    } = await refreshToken();
+    const { data: roomData } = await getRoomInfo(params.roomId, {
+        headers: {
+            Authorization: `Bearer ${access_token}`,
+        },
+        credentials: "include",
+    });
 
     return {
         title: roomData?.room_name ?? `방 ${params.roomId}`,


### PR DESCRIPTION
## 개요
- generateMetadata 시 리프레시 토큰 동작 수정


## 작업 사항
- 메타데이터를 만들기 위해 서버 요청하면서 리프레시 토큰을 못 가져와서 터짐
- fetchClient 안에서 해보려고 했는데 리프레시 토큰 요청도 fetchClient를 사용해서 순환됨
- 그래서 그냥 필요한 페이지에서 다시 refreshToken (server) 을 호출해서 인자에 직접 넣어주는 식으로 변경
- 더 좋은 방법이 있긴 할 거 같은데 우선은 이렇게 했습니다


## 리뷰 요청 사항
