### PR TITLE
fix: 푸시 알림 관련 코드 개선

### DIFF
--- a/client/src/apis/repository/notification.repository.ts
+++ b/client/src/apis/repository/notification.repository.ts
@@ -1,6 +1,10 @@
 import { baseClient } from "@/modules/fetchClient";
 import { Subscription } from "@/types/subscription.type";
 
+export const getSubscriptionFromDB = async () => {
+    return await baseClient.get<Subscription | null>("/notification");
+};
+
 export const createSubscriptionToDB = async (subscription: Subscription) => {
     return await baseClient.post<Subscription>("/notification", { notification: subscription });
 };

--- a/client/src/apis/service/notification.service.ts
+++ b/client/src/apis/service/notification.service.ts
@@ -12,9 +12,11 @@ const getServiceWorkerStatus = async () => {
     return navigator.serviceWorker.ready;
 };
 
-export const getExistingSubscription = async () => {
-    const serviceWorker = await getServiceWorkerStatus();
+// 브라우저의 기존 푸시 구독을 가져오는 함수  getSubscriptionFromBrowser
+export const getSubscriptionFromBrowser = async () => {
+    const serviceWorker = await getServiceWorkerStatus(); // 서비스 워커 준비된 상태인지 확인
     return serviceWorker.pushManager.getSubscription();
+    // 브라우저의 기존 푸시 구독을 가져옴. null 혹은 PushSubscription 객체 반환
 };
 
 export const startSubscription = async () => {
@@ -24,7 +26,7 @@ export const startSubscription = async () => {
             return;
         }
 
-        const existingSubscription = await getExistingSubscription();
+        const existingSubscription = await getSubscriptionFromBrowser();
 
         if (existingSubscription) {
             return; // 이미 구독 있음
@@ -60,7 +62,7 @@ const formatSubscription = async (subscription: PushSubscription) => {
 };
 
 export const cancelSubscription = async () => {
-    const existingSubscription = await getExistingSubscription();
+    const existingSubscription = await getSubscriptionFromBrowser();
 
     if (!existingSubscription) {
         return; // 취소할 구독이 없다.

--- a/client/src/apis/service/notification.service.ts
+++ b/client/src/apis/service/notification.service.ts
@@ -12,17 +12,15 @@ const getServiceWorkerStatus = async () => {
     return navigator.serviceWorker.ready;
 };
 
-// 브라우저의 기존 푸시 구독을 가져오는 함수  getSubscriptionFromBrowser
 export const getSubscriptionFromBrowser = async () => {
-    const serviceWorker = await getServiceWorkerStatus(); // 서비스 워커 준비된 상태인지 확인
+    const serviceWorker = await getServiceWorkerStatus();
     return serviceWorker.pushManager.getSubscription();
-    // 브라우저의 기존 푸시 구독을 가져옴. null 혹은 PushSubscription 객체 반환
 };
 
 export const startSubscription = async () => {
     try {
         if (!("PushManager" in window)) {
-            alert("푸시 알림 이 브라우저에서 지원 안 함");
+            alert("현재 브라우저에서 푸시 알림을 지원하지 않습니다");
             return;
         }
 
@@ -43,7 +41,7 @@ export const startSubscription = async () => {
     } catch (error) {
         console.error(error);
         if (Notification.permission === "denied") {
-            alert("알림 허용해주세요");
+            alert("푸시 알림을 허용해주세요");
         }
     }
 };

--- a/client/src/apis/service/notification.service.ts
+++ b/client/src/apis/service/notification.service.ts
@@ -1,10 +1,12 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import {
     createSubscriptionToDB,
     deleteSubscriptionFromDB,
     createPushNotification,
+    getSubscriptionFromDB,
 } from "../repository/notification.repository";
 import { Subscription } from "@/types/subscription.type";
+import { QUERY_KEY } from "@/constants/queryKey.const";
 
 const getServiceWorkerStatus = async () => {
     return navigator.serviceWorker.ready;
@@ -67,6 +69,16 @@ export const cancelSubscription = async () => {
     existingSubscription.unsubscribe();
 
     return true;
+};
+
+export const useGetSubscriptionFromDB = () => {
+    return useQuery({
+        queryKey: QUERY_KEY.subscription,
+        queryFn: async () => {
+            const { data } = await getSubscriptionFromDB();
+            return data;
+        },
+    });
 };
 
 export const useCreateSubscriptionToDB = () => {

--- a/client/src/components/menu/notificationSwitch/notificationSwitch.tsx
+++ b/client/src/components/menu/notificationSwitch/notificationSwitch.tsx
@@ -2,22 +2,43 @@ import { useState, useEffect } from "react";
 import {
     startSubscription,
     cancelSubscription,
-    getExistingSubscription,
+    getSubscriptionFromBrowser,
     useCreateSubscriptionToDB,
     useDeleteSubscriptionFromDB,
+    useGetSubscriptionFromDB,
 } from "@/apis/service/notification.service";
 import style from "./notificationSwitch.module.scss";
 
 const NotificationSwitch = () => {
+    const {
+        data: DBSubscription,
+        isLoading: isDBLoading,
+        error: dbError,
+    } = useGetSubscriptionFromDB();
     const [hasSubscription, setHasSubscription] = useState<boolean>();
 
     useEffect(() => {
+        if (isDBLoading) return;
+
         const getActiveSubscription = async () => {
-            const subscription = await getExistingSubscription();
-            setHasSubscription(!!subscription);
+            try {
+                // DB 에러가 있거나 DB 구독이 없으면 구독 없음
+                if (dbError || !DBSubscription) {
+                    setHasSubscription(false);
+                    return;
+                }
+
+                // 브라우저 구독 확인
+                const browserSubscription = await getSubscriptionFromBrowser();
+                setHasSubscription(!!browserSubscription);
+            } catch (error) {
+                console.error("브라우저 구독 확인 실패:", error);
+                setHasSubscription(false);
+            }
         };
+
         getActiveSubscription();
-    }, []);
+    }, [DBSubscription, isDBLoading, dbError]);
 
     const { mutate: createSubscription } = useCreateSubscriptionToDB();
     const { mutate: deleteSubscription } = useDeleteSubscriptionFromDB();

--- a/client/src/components/menu/notificationSwitch/notificationSwitch.tsx
+++ b/client/src/components/menu/notificationSwitch/notificationSwitch.tsx
@@ -22,13 +22,11 @@ const NotificationSwitch = () => {
 
         const getActiveSubscription = async () => {
             try {
-                // DB 에러가 있거나 DB 구독이 없으면 구독 없음
                 if (dbError || !DBSubscription) {
                     setHasSubscription(false);
                     return;
                 }
 
-                // 브라우저 구독 확인
                 const browserSubscription = await getSubscriptionFromBrowser();
                 setHasSubscription(!!browserSubscription);
             } catch (error) {

--- a/client/src/components/room/roomContent.tsx
+++ b/client/src/components/room/roomContent.tsx
@@ -87,6 +87,20 @@ const RoomContent = () => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
+    useEffect(() => {
+        const registerServiceWorker = async () => {
+            if (!("serviceWorker" in navigator)) {
+                alert(
+                    "이 브라우저는 서비스 워커를 제공하지 않아 푸시 알림 기능이 지원되지 않습니다.",
+                );
+                return;
+            }
+
+            await navigator.serviceWorker.register("/serviceWorker.js");
+        };
+        registerServiceWorker();
+    }, []);
+
     return (
         <main className={style.main}>
             <RoomGradientBackground className={style.gradient_background} />

--- a/client/src/constants/queryKey.const.ts
+++ b/client/src/constants/queryKey.const.ts
@@ -4,8 +4,9 @@ export const QUERY_KEY = {
     room: (roomId?: string) => {
         const baseKey = ["room"];
         if (roomId) {
-            return baseKey.concat(roomId);  
+            return baseKey.concat(roomId);
         }
         return baseKey;
     },
+    subscription: ["subscription"],
 };

--- a/server/src/modules/notification/notification.controller.ts
+++ b/server/src/modules/notification/notification.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Post, UseGuards } from "@nestjs/common";
+import { Body, Controller, Delete, Get, Post, UseGuards } from "@nestjs/common";
 import { CurrentUser } from "src/common/decorators/user.decorator";
 import { JwtGuard } from "src/common/guards/auth.guard";
 import { User } from "src/modules/users/schemas/user.schema";
@@ -11,6 +11,15 @@ import { ResponseDto } from "src/common/interfaces/response.interface";
 export class NotificationController {
     constructor(private readonly notificationService: NotificationService) {}
 
+    @Get()
+    async getSubscriptionFromDB(@CurrentUser() user: User): Promise<ResponseDto> {
+        const subscription = await this.notificationService.getSubscription(user.id);
+        return {
+            data: subscription,
+            message: "알림 구독 정보가 성공적으로 조회되었습니다",
+        };
+    }
+
     @Post()
     async createSubscriptionToDB(
         @CurrentUser() user: User,
@@ -19,7 +28,7 @@ export class NotificationController {
         const result = await this.notificationService.createSubscription(user.id, subscription);
         return {
             data: result,
-            message: "알림 구독이 성공적으로 등록되었습니다"
+            message: "알림 구독이 성공적으로 등록되었습니다",
         };
     }
 
@@ -28,7 +37,7 @@ export class NotificationController {
         const result = await this.notificationService.deleteSubscription(user.id);
         return {
             data: result,
-            message: "알림 구독이 성공적으로 해제되었습니다"
+            message: "알림 구독이 성공적으로 해제되었습니다",
         };
     }
 
@@ -37,7 +46,7 @@ export class NotificationController {
         const result = await this.notificationService.createPushNotification(userIds);
         return {
             data: result,
-            message: "푸시 알림이 성공적으로 전송되었습니다"
+            message: "푸시 알림이 성공적으로 전송되었습니다",
         };
     }
 }

--- a/server/src/modules/notification/notification.controller.ts
+++ b/server/src/modules/notification/notification.controller.ts
@@ -13,7 +13,7 @@ export class NotificationController {
 
     @Get()
     async getSubscriptionFromDB(@CurrentUser() user: User): Promise<ResponseDto> {
-        const subscription = await this.notificationService.getSubscription(user.id);
+        const subscription = await this.notificationService.getSubscription(user._id);
         return {
             data: subscription,
             message: "알림 구독 정보가 성공적으로 조회되었습니다",
@@ -25,7 +25,7 @@ export class NotificationController {
         @CurrentUser() user: User,
         @Body("notification") subscription: SubscriptionDTO,
     ): Promise<ResponseDto> {
-        const result = await this.notificationService.createSubscription(user.id, subscription);
+        const result = await this.notificationService.createSubscription(user._id, subscription);
         return {
             data: result,
             message: "알림 구독이 성공적으로 등록되었습니다",
@@ -34,7 +34,7 @@ export class NotificationController {
 
     @Delete()
     async deleteSubscriptionFromDB(@CurrentUser() user: User): Promise<ResponseDto> {
-        const result = await this.notificationService.deleteSubscription(user.id);
+        const result = await this.notificationService.deleteSubscription(user._id);
         return {
             data: result,
             message: "알림 구독이 성공적으로 해제되었습니다",

--- a/server/src/modules/notification/notification.service.ts
+++ b/server/src/modules/notification/notification.service.ts
@@ -20,11 +20,7 @@ export class NotificationService {
     }
 
     createSubscription(userId: Types.ObjectId, subscription: SubscriptionDTO) {
-        const user = this.userModel.updateOne(
-            { _id: userId },
-            { $addToSet: { notification: subscription } },
-        );
-        return user;
+        return this.userModel.updateOne({ _id: userId }, { $set: { notification: subscription } });
     }
 
     async deleteSubscription(userId: Types.ObjectId) {

--- a/server/src/modules/notification/notification.service.ts
+++ b/server/src/modules/notification/notification.service.ts
@@ -19,6 +19,12 @@ export class NotificationService {
         );
     }
 
+    async getSubscription(userId: Types.ObjectId) {
+        const user = await this.userModel.findById(userId).lean();
+
+        return user?.notification || null;
+    }
+
     createSubscription(userId: Types.ObjectId, subscription: SubscriptionDTO) {
         return this.userModel.updateOne({ _id: userId }, { $set: { notification: subscription } });
     }


### PR DESCRIPTION
## 개요
<!-- 한 줄 정도로 어떤 PR인지 설명해주세요 -->
푸시 알림 관련 코드를 강화(?)하였습니다

## 작업 사항
<!-- 가능하다면 스크린샷을 첨부해주세요 -->
- **룸 내에서 없어진 `registerServiceWorker` 함수 살림**
  https://github.com/FE-Ocean/MEETSIN/pull/89/files#diff-dbe5037213598f4d446a0c472dea4d9f9c4afac83d5508f4bad4f6248f24cb69 여기서 메타 데이터 작업할 때 서비스 워커 활성화 시키는 코드가 없어져서 살림

- **구독 객체는 등록 시마다 갱신 되도록 변경**
  기존에는 구독 시마다 객체가 여러 개 등록됨

- **DB의 구독 상태도 확인 후, notification switch의 구독 상태 처리**
  기존에는 브라우저의 구독 상태만으로 notification switch의 구독 상태를 나타냈으나,
  브라우저, DB 모두 확인하는 것으로 변경

## 리뷰 요청 사항
한 브라우저로 여러 아이디 로그인 시에 발생할 수 있는 푸시 알림 관련 문제들을 생각하며 수정하였습니다. 제가 미처 생각하지 못한 부분이 있다면 알려주세요..